### PR TITLE
make instructions link point to new readme

### DIFF
--- a/src/app/download/page.tsx
+++ b/src/app/download/page.tsx
@@ -59,7 +59,7 @@ export default function Downloads() {
           <Link
             className="underline hover:opacity-90"
             href={
-              "https://github.com/DesktopDefender/DesktopDefender?tab=readme-ov-file#setup-using-the-landing-page"
+			  "https://github.com/DesktopDefender/DesktopDefender?tab=readme-ov-file#1-downloading-a-binary"
             }
           >
             in the repository's README

--- a/src/app/download/page.tsx
+++ b/src/app/download/page.tsx
@@ -59,7 +59,7 @@ export default function Downloads() {
           <Link
             className="underline hover:opacity-90"
             href={
-			  "https://github.com/DesktopDefender/DesktopDefender?tab=readme-ov-file#1-downloading-a-binary"
+              "https://github.com/DesktopDefender/DesktopDefender?tab=readme-ov-file#1-downloading-a-binary"
             }
           >
             in the repository's README


### PR DESCRIPTION
readme instructions in app repository were updated in [#25](https://github.com/DesktopDefender/DesktopDefender/commit/a86b4cda0b48c9799fdae31eb75a9e93c77e6ada)

This PR makes the landing page point towards the section in the new readme, as the old one is currently not up to date